### PR TITLE
code coverage on the right files

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,8 @@ require 'coveralls'
 SimpleCov.formatter = Coveralls::SimpleCov::Formatter
 SimpleCov.start do
   track_files "bin/**/*"
+  track_files "devel/**/*.rb"
+  add_filter "spec/**/*"
 end
 
 puts "running in #{ENV['ROBOT_ENVIRONMENT']} mode"


### PR DESCRIPTION
turns out coveralls was tracking coverage on spec files, and NOT on the code in the devel folder.  whoops.