### PR TITLE
remove coverage for spec files

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,7 @@ SimpleCov.formatter = Coveralls::SimpleCov::Formatter
 SimpleCov.start do
   track_files "bin/**/*"
   track_files "devel/**/*.rb"
-  add_filter "spec/**/*"
+  add_filter "spec/**/*.rb"
 end
 
 puts "running in #{ENV['ROBOT_ENVIRONMENT']} mode"


### PR DESCRIPTION
we don't want code coverage for spec files and I got it wrong before.