### PR TITLE
configure new dor-workflow-client correctly and fix call to initiate workflow

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem 'dir_validator'
 # gem 'dor-fetcher'   # not supported anymore; only used by devel/get_dor_and_sdr_versions.rb script, which is not regularly used
 gem 'dor-services', '< 6'
 gem 'dor-services-client'
+gem 'dor-workflow-client'
 gem 'druid-tools'
 gem 'harvestdor'
 gem 'modsulator'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,6 +151,13 @@ GEM
       moab-versioning (~> 4.0)
       nokogiri (~> 1.8)
       zeitwerk (~> 2.1)
+    dor-workflow-client (3.7.0)
+      activesupport (>= 3.2.1, < 7)
+      deprecation (>= 0.99.0)
+      faraday (~> 0.9, >= 0.9.2)
+      faraday_middleware
+      nokogiri (~> 1.6)
+      zeitwerk (~> 2.1)
     dor-workflow-service (2.12.0)
       activesupport (>= 3.2.1, < 6)
       confstruct (>= 0.2.7, < 2)
@@ -194,6 +201,8 @@ GEM
     erubis (2.7.0)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.13.1)
+      faraday (>= 0.7.4, < 1.0)
     fastercsv (1.5.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -415,6 +424,7 @@ DEPENDENCIES
   dlss-capistrano (~> 3.1)
   dor-services (< 6)
   dor-services-client
+  dor-workflow-client
   druid-tools
   equivalent-xml
   harvestdor
@@ -434,4 +444,4 @@ DEPENDENCIES
   stanford-mods
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -8,15 +8,7 @@ CERT_DIR = File.join(File.dirname(__FILE__), ".", "certs")
 
 # General DLSS infrastructure.
 require 'dor-services'
-require 'dor-workflow-service'
-
-# Environment.
-unless defined?(NO_ENVIRONMENT)
-  ENV_FILE = PRE_ASSEMBLY_ROOT + "/config/environments/#{environment}.rb"
-  require ENV_FILE
-  Dor::Config.dor_services.url ||= Dor::Config.dor.service_root
-  Dor::Config.workflow.client.configure(Dor::Config.workflow.url,:dor_services_url => Dor::Config.dor_services.url.gsub('/v1',''))
-end
+require 'dor/workflow/client'
 
 # Project dir in load path.
 $LOAD_PATH.unshift(PRE_ASSEMBLY_ROOT + '/lib')
@@ -30,6 +22,14 @@ require 'awesome_print' if ['local', 'development'].include? environment
 
 # Load the project and its dependencies.
 require 'pre_assembly'
+
+# Environment.
+unless defined?(NO_ENVIRONMENT)
+  ENV_FILE = PRE_ASSEMBLY_ROOT + "/config/environments/#{environment}.rb"
+  require ENV_FILE
+  Dor::Services::Client.configure(url: Dor::Config.dor_services.url,
+                                  token: Dor::Config.dor_services.token)
+end
 
 require 'revs-utils'
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,7 +1,11 @@
 Dor::Config.configure do
   dor do
-    service_root 'https://example.com/dor/v1'
     sleep_time 0
     num_attempts 1
+  end
+
+  dor_services do
+    url 'https://test'
+    token 'test'
   end
 end

--- a/lib/pre_assembly/digital_object.rb
+++ b/lib/pre_assembly/digital_object.rb
@@ -497,16 +497,14 @@ module PreAssembly
       log "    - initialize_assembly_workflow()"
 
        with_retries(max_tries: Dor::Config.dor.num_attempts, rescue: Exception, handler: PreAssembly.retry_handler('INITIALIZE_ASSEMBLY_WORKFLOW', method(:log))) do
-          api_client.object(@druid.druid).workflow.create(wf_name: workflow_name)
+          api_client.create_workflow_by_name(@druid.druid, workflow_name)
        end
     end
 
     private
 
     def api_client
-      @api_client ||= Dor::Services::Client.configure(url: Dor::Config.dor_services.url,
-                                                      username: Dor::Config.dor_services.user,
-                                                      password: Dor::Config.dor_services.pass)
+      @api_client ||= Dor::Workflow::Client.new(url: Dor::Config.workflow.url)
     end
 
     def workflow_name

--- a/spec/digital_object_spec.rb
+++ b/spec/digital_object_spec.rb
@@ -806,7 +806,6 @@ describe PreAssembly::DigitalObject do
     end
 
     let(:client) { double }
-    let(:service_url) { 'http://example.edu/dor/services/endpoint' }
 
     context 'when @init_assembly_wf is false' do
       before do
@@ -821,18 +820,19 @@ describe PreAssembly::DigitalObject do
 
     context 'when @init_assembly_wf is true' do
       before do
-        allow(client).to receive_message_chain(:object, :workflow, :create)
+        allow(client).to receive(:create_workflow_by_name)
       end
 
       it 'starts the assembly workflow' do
         expect(@dobj).to receive(:api_client)
+        expect(client).to receive(:create_workflow_by_name).with(@pid, 'assemblyWF')
         @dobj.initialize_assembly_workflow
       end
     end
 
     context 'when the api client raises' do
       before do
-        allow(client).to receive_message_chain(:object, :workflow, :create).and_raise(Exception)
+        allow(client).to receive(:create_workflow_by_name).and_raise(Exception)
       end
 
       it 'raises an exception' do

--- a/spec/digital_object_spec.rb
+++ b/spec/digital_object_spec.rb
@@ -805,7 +805,7 @@ describe PreAssembly::DigitalObject do
       @dobj.druid = @druid
     end
 
-    let(:client) { double }
+    let(:client) { instance_double(Dor::Workflow::Client) }
 
     context 'when @init_assembly_wf is false' do
       before do


### PR DESCRIPTION
The call to initialize assemblyWF is currently failing in legacy pre-assembly due to it trying to call the old workflow service.  This correctly configures dor-services and workflow and calls the new workflow service using the dor-workflow-client.  Correct URLs are configured on the legacy server already.

Note: we are currently using an old version for dor-services that doesn't have the new dor-workflow-client already configured.  Updating to latest dor-services is complex for various reasons and is deferred