### PR TITLE
[Needs to be Vetted!] fix deploy to work on stage and prod

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 dist: bionic
 language: ruby
 cache: bundler
-env:
-  global:
-    - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up bundle install
 
 sudo: false
 notifications:

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem 'harvestdor'
 gem 'modsulator'
 gem 'stanford-mods'
 gem 'config'
+gem 'pry-byebug' # helpful for debugging problems
 
 group :test do
   gem 'coveralls', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,7 @@ GEM
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
       zeitwerk (~> 2.1)
+    coderay (1.1.2)
     concurrent-ruby (1.1.5)
     config (2.2.1)
       deep_merge (~> 1.2, >= 1.2.1)
@@ -239,6 +240,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
+    method_source (0.9.2)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.1009)
@@ -286,6 +288,12 @@ GEM
     parallel (1.19.1)
     parser (2.7.0.2)
       ast (~> 2.4.0)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-byebug (3.8.0)
+      byebug (~> 11.0)
+      pry (~> 0.10)
     rack (2.1.1)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -433,6 +441,7 @@ DEPENDENCIES
   jettywrapper
   modsulator
   nokogiri
+  pry-byebug
   rake
   rdf
   rest-client

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -29,7 +29,7 @@ set :deploy_to, '/home/scripts/lyberservices-scripts'
 set :linked_files, %w{config/honeybadger.yml}
 
 # Default value for linked_dirs is []
-set :linked_dirs, %w{log config/certs config/environments tmp vendor/bundle}
+set :linked_dirs, %w{log config/certs config/environments config/settings tmp vendor/bundle}
 
 # Default value for default_env is {}
 # set :default_env, { path: "/opt/ruby/bin:$PATH" }


### PR DESCRIPTION
HOLD:  
- [x] @peetucket must review, and 
- [ ] @peetucket and/or @andrewjbtw must test this branch 
    - [x] on stage and 
    - [ ] prod to ensure the fix to stage won't break prod.
- [ ] we need to remove some cruft from prod's shared folder

## Why was this change made?

to fix this error when running `pre-assemble` script on stage:

```
Working on '/dor/staging/versioning-test/the-actual-content/kt849tp3820' containing 2 files
** [Honeybadger] Reporting error id=862f2c13-8cac-4a5c-973d-9b134e8682a9 level=1 pid=21539
** [Honeybadger] Reporting error id=613cb8e8-182e-40da-b3cd-9ec7024e3fe1 level=1 pid=21539
** [Honeybadger] Success ⚡ https://app.honeybadger.io/notice/862f2c13-8cac-4a5c-973d-9b134e8682a9 id=862f2c13-8cac-4a5c-973d-9b134e8682a9 code=201 level=1 pid=21539
** [Honeybadger] Error report failed: project is sending too many errors. id=613cb8e8-182e-40da-b3cd-9ec7024e3fe1 code=0 throttle=1.25 interval=429 level=2 pid=21539
Traceback (most recent call last):
	23: from bin/pre-assemble:35:in `<main>'
	22: from /home/scripts/lyberservices-scripts/releases/20200130225250/lib/pre_assembly/bundle.rb:308:in `run_pre_assembly'
	21: from /home/scripts/lyberservices-scripts/releases/20200130225250/lib/pre_assembly/bundle.rb:659:in `process_digital_objects'
	20: from /home/scripts/lyberservices-scripts/releases/20200130225250/lib/pre_assembly/bundle.rb:659:in `each'
	19: from /home/scripts/lyberservices-scripts/releases/20200130225250/lib/pre_assembly/bundle.rb:676:in `block in process_digital_objects'
	18: from /home/scripts/lyberservices-scripts/releases/20200130225250/lib/pre_assembly/digital_object.rb:141:in `pre_assemble'
	17: from /home/scripts/lyberservices-scripts/releases/20200130225250/lib/pre_assembly/digital_object.rb:471:in `openable?'
	16: from /home/scripts/lyberservices-scripts/shared/bundle/ruby/2.5.0/gems/dor-services-client-4.1.0/lib/dor/services/client/object_version.rb:34:in `openable?'
	15: from /home/scripts/lyberservices-scripts/shared/bundle/ruby/2.5.0/gems/faraday-0.17.3/lib/faraday/connection.rb:138:in `get'
	14: from /home/scripts/lyberservices-scripts/shared/bundle/ruby/2.5.0/gems/faraday-0.17.3/lib/faraday/connection.rb:387:in `run_request'
	13: from /home/scripts/lyberservices-scripts/shared/bundle/ruby/2.5.0/gems/faraday-0.17.3/lib/faraday/rack_builder.rb:143:in `build_response'
	12: from /home/scripts/lyberservices-scripts/shared/bundle/ruby/2.5.0/gems/dor-services-client-4.1.0/lib/dor/services/client/error_faraday_middleware.rb:9:in `call'
	11: from /home/scripts/lyberservices-scripts/shared/bundle/ruby/2.5.0/gems/faraday-0.17.3/lib/faraday/request/url_encoded.rb:15:in `call'
	10: from /home/scripts/lyberservices-scripts/shared/bundle/ruby/2.5.0/gems/faraday-0.17.3/lib/faraday/adapter/net_http.rb:38:in `call'
	 9: from /home/scripts/lyberservices-scripts/shared/bundle/ruby/2.5.0/gems/faraday-0.17.3/lib/faraday/adapter/net_http.rb:92:in `with_net_http_connection'
	 8: from /home/scripts/lyberservices-scripts/shared/bundle/ruby/2.5.0/gems/faraday-0.17.3/lib/faraday/adapter/net_http.rb:43:in `block in call'
	 7: from /home/scripts/lyberservices-scripts/shared/bundle/ruby/2.5.0/gems/faraday-0.17.3/lib/faraday/adapter/net_http.rb:85:in `perform_request'
	 6: from /usr/local/rvm/rubies/ruby-2.5.3/lib/ruby/2.5.0/net/http.rb:1213:in `get'
	 5: from /usr/local/rvm/rubies/ruby-2.5.3/lib/ruby/2.5.0/net/http.rb:1455:in `request'
	 4: from /usr/local/rvm/rubies/ruby-2.5.3/lib/ruby/2.5.0/net/http.rb:909:in `start'
	 3: from /usr/local/rvm/rubies/ruby-2.5.3/lib/ruby/2.5.0/net/http.rb:920:in `do_start'
	 2: from /usr/local/rvm/rubies/ruby-2.5.3/lib/ruby/2.5.0/net/http.rb:981:in `connect'
	 1: from /usr/local/rvm/rubies/ruby-2.5.3/lib/ruby/2.5.0/net/protocol.rb:44:in `ssl_socket_connect'
/usr/local/rvm/rubies/ruby-2.5.3/lib/ruby/2.5.0/net/protocol.rb:44:in `connect_nonblock': SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed (ok) (Faraday::SSLError)
```

## Was the usage documentation (e.g. README, consul, DevOpsDocs, wiki) updated?
