### PR TITLE
we need to properly call the assembly-objectfile constructor to get defaults

### DIFF
--- a/lib/pre_assembly/object_file.rb
+++ b/lib/pre_assembly/object_file.rb
@@ -3,14 +3,12 @@ require 'assembly-objectfile'
 class PreAssembly::ObjectFile < Assembly::ObjectFile
 
   attr_accessor(
-    :relative_path,
     :exclude_from_content,
     :checksum
   )
 
   def initialize(params = {})
-    @path                 = params[:path]
-    @relative_path        = params[:relative_path]
+    super(params[:path], params) # we need to be sure to call Assembly::ObjectFile's constructor to get any defaults set there
     self.checksum         = params[:checksum]
     @exclude_from_content = params[:exclude_from_content]
   end
@@ -29,4 +27,3 @@ class PreAssembly::ObjectFile < Assembly::ObjectFile
   end
 
 end
-


### PR DESCRIPTION
## Why was this change made?

assembly-objectfile 1.9 introduces some changes to the constructor that requires that we call it if we override it

## Was the usage documentation (e.g. README, consul, DevOpsDocs, wiki) updated?
