### PR TITLE
Removed broken code

### DIFF
--- a/config/projects/TEMPLATE.yaml
+++ b/config/projects/TEMPLATE.yaml
@@ -29,7 +29,7 @@ progress_log_file: ~                        # Optional - if left as nil a progre
 
 apo_druid_id:      'druid:aa111bb2222'     # Required if pre-assembly is registering
                                            # the objects.  Include druid prefix.
-                                           # NOTE: only valid if should_register = true OR get_druid_from = container_barcode
+                                           # NOTE: only valid if should_register = true
 
 set_druid_id:      'druid:yy888xx9999'     # If supplied, pre-assembly will associate
                                            # the object with a set in Dor. Include druid prefix.
@@ -84,9 +84,6 @@ project_style:
 
                   'container'          # Object is contained in a druid subdirectory
                                        # For example: "aa111bb2222".
-
-                  'container_barcode'  # Object is contained in a barcode subdirectory.  Druid will be fetched from a service.
-                                       # For example: "36105115575834".
 
                   'manifest'           # Object's druid is in a column in the manifest called "druid".  Only used for should_register=false and use_manifest=true
                                        #   when you want to use a manifest for descriptive metadata, and when the folder container is not named by druid
@@ -156,7 +153,7 @@ stageable_discovery:
 
   # Option 1: If you set 'use_container' to true, this will simply stage the entire object directory that was matched with the glob above.
   # This is not a valid option if your object is contained in a folder named by druid or barcode - preassembly will give an error message if you set
-  # 'use_container' to true and the 'get_druid_from' parameter to 'container' or 'container_barcode'.
+  # 'use_container' to true and the 'get_druid_from' parameter to 'container'.
 
   use_container: true    # If true , set glob and regex to nil below.
                  false   # If false, use glob and regex below.

--- a/lib/pre_assembly/bundle.rb
+++ b/lib/pre_assembly/bundle.rb
@@ -149,7 +149,7 @@ module PreAssembly
       {
         :project_style=>{
           :content_structure=>[:simple_image,:simple_book,:book_as_image,:book_with_pdf,:file,:smpl,:'3d'],
-          :get_druid_from=>[:suri,:container,:container_barcode,:manifest,:druid_minter],
+          :get_druid_from=>[:suri,:container,:manifest,:druid_minter],
         },
         :content_md_creation=>{
           :style=>[:default,:filename,:dpg,:smpl,:salt,:none],
@@ -231,12 +231,7 @@ module PreAssembly
         validation_errors << "If should_register=true, then you must use a manifest." unless @object_discovery[:use_manifest] # you have to use a manifest if you want to register objects
         validation_errors << "If should_register=true, it does not make sense to have project_style:content_tag_override=true since objects are not registered yet." if @project_style[:content_tag_override]
       else  # if should_register=false, check some stuff
-        if @project_style[:get_druid_from] != :container_barcode
-          validation_errors << "The APO and SET DRUIDs should not be set if should_register = false." if (@apo_druid_id || @set_druid_id)  # APO and SET should not be set
-        else
-          validation_errors << "The APO DRUID must be set if project_style:get_druid_from = container_barcode." if @apo_druid_id.blank? # APO DRUID must be added for container_barcode projects
-          validation_errors << "The SET DRUID should not be set if project_style:get_druid_from = container_barcode." if @set_druid_id # SET DRUID must not be set for container_barcode projects
-        end
+        validation_errors << "The APO and SET DRUIDs should not be set if should_register = false." if (@apo_druid_id || @set_druid_id)  # APO and SET should not be set
         validation_errors << "get_druid_from: 'suri' is only valid if should_register = true." if @project_style[:get_druid_from]==:suri # can't use SURI to get druid
         validation_errors << "get_druid_from: 'manifest' is only valid if use_manifest = true." if @project_style[:get_druid_from]==:manifest && @object_discovery[:use_manifest] == false # can't use SURI to get druid
       end

--- a/lib/pre_assembly/digital_object.rb
+++ b/lib/pre_assembly/digital_object.rb
@@ -167,26 +167,6 @@ module PreAssembly
       "druid:#{container_basename}"
     end
 
-    def get_pid_from_container_barcode
-      barcode = container_basename
-      pids    = query_dor_by_barcode(barcode)
-      pids.each do |pid|
-        @pid=pid
-        apo_pids = get_dor_item_apos.map { |apo| apo.pid }
-        return pid if apo_matches_exactly_one?(apo_pids)
-      end
-      nil
-    end
-
-    def query_dor_by_barcode(barcode)
-      Dor::SearchService.query_by_id :barcode => barcode
-    end
-
-    def get_dor_item_apos(pid)
-      get_dor_object
-      @dor_object.nil? ? [] : @dor_object.admin_policy_object
-    end
-
     def get_dor_object
       begin
         @dor_object ||= Dor::Item.find pid

--- a/lib/pre_assembly/reporting.rb
+++ b/lib/pre_assembly/reporting.rb
@@ -34,7 +34,6 @@ module PreAssembly
       checking_sourceids=check_sourceids && using_manifest
 
       confirming_registration=(no_check_reg == false && @project_style[:should_register] == false)
-      barcode_project=@project_style[:get_druid_from] == :container_barcode
 
       log ""
       log "discovery_report(#{run_log_msg})"
@@ -143,9 +142,6 @@ module PreAssembly
          source_ids[dobj.source_id] += 1 if using_manifest # keep track of source_id uniqueness
 
          if confirming_registration # objects should already be registered, let's confirm that
-           if barcode_project # look up druid by container and confirm we can find one
-             druid_from_container=dobj.get_pid_from_container_barcode || report_error_message("druid not found from barcode")
-           end
            dobj.determine_druid
            pid = dobj.pid
            druid = pid.include?('druid') ? pid : "druid:#{pid}"

--- a/spec/digital_object_spec.rb
+++ b/spec/digital_object_spec.rb
@@ -48,40 +48,13 @@ describe PreAssembly::DigitalObject do
 
   ####################
 
-  describe "determining druid: get_pid_from_container_barcode()" do
-
-    before(:each) do
-      @druids = %w(druid:aa00aaa0000 druid:cc11bbb1111 druid:dd22eee2222)
-      apos = %w(druid:aa00aaa9999 druid:bb00bbb9999 druid:cc00ccc9999)
-      apos = apos.map { |a| double('apo', :pid => a) }
-      @barcode = '36105115575834'
-      allow(@dobj).to receive(:container_basename).and_return @barcode
-      allow(@dobj).to receive(:query_dor_by_barcode).and_return @druids
-      allow(@dobj).to receive(:get_dor_item_apos).and_return apos
-      @stubbed_return_vals = @druids.map { false }
-    end
-
+  describe "#get_pid_from_druid_minter" do
     it "should return DruidMinter.next if get_druid_from=druid_minter" do
       exp = PreAssembly::DruidMinter.current
       @dobj.project_style[:get_druid_from] = :druid_minter
       expect(@dobj).not_to receive :container_basename
       expect(@dobj.get_pid_from_druid_minter).to eq(exp.next)
     end
-
-    it "should return nil whether there are no matches" do
-      allow(@dobj).to receive(:apo_matches_exactly_one?).and_return *@stubbed_return_vals
-      expect(@dobj.get_pid_from_container_barcode).to eq(nil)
-    end
-
-    it "should return the druid of the object with the matching APO" do
-      @druids.each_with_index do |druid, i|
-        @stubbed_return_vals[i] = true
-        allow(@dobj).to receive(:apo_matches_exactly_one?).and_return *@stubbed_return_vals
-        expect(@dobj.get_pid_from_container_barcode).to eq(@druids[i])
-        @stubbed_return_vals[i] = false
-      end
-    end
-
   end
 
   ####################


### PR DESCRIPTION
## Why was this change made?

This code was not runnable and was presumably dead.  Removing it helps us migrate away from dependency on Fedora 3.

How do we know?  Because the `get_pid_from_container_barcode` method was calling
`get_dor_item_apos` with zero arguments, but the method takes one argument.  Since this path
wouldn't work anyway, I'm removing this code.


## Was the usage documentation (e.g. README, consul, DevOpsDocs, wiki) updated?
 n/a