### PR TITLE
Don't retry workflow requests

### DIFF
--- a/lib/pre_assembly/digital_object.rb
+++ b/lib/pre_assembly/digital_object.rb
@@ -470,9 +470,7 @@ module PreAssembly
       return unless @init_assembly_wf
       log "    - initialize_assembly_workflow()"
 
-       with_retries(max_tries: Settings.num_attempts, rescue: Exception, handler: PreAssembly.retry_handler('INITIALIZE_ASSEMBLY_WORKFLOW', method(:log))) do
-          workflow_client.create_workflow_by_name(@druid.druid, 'assemblyWF', version: current_object_version)
-       end
+      workflow_client.create_workflow_by_name(@druid.druid, 'assemblyWF', version: current_object_version)
     end
 
     def workflow_client


### PR DESCRIPTION

## Why was this change made?

The client has retry built in:
https://github.com/sul-dlss/dor-workflow-client/blob/9098b28d74f3fbde9a66bfd577171a0636cbeb7a/lib/dor/workflow/client/connection_factory.rb#L31-L39


## Was the usage documentation (e.g. README, consul, DevOpsDocs, wiki) updated?
 n/a