### PR TITLE
remove unused gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ gem 'csv-mapper'
 gem 'equivalent-xml'
 gem 'nokogiri'
 gem 'rake'
-# gem 'rdf' # seems we don't need this??
 gem 'rest-client'
 gem 'retries'
 gem 'roo'
@@ -15,13 +14,12 @@ gem 'honeybadger', '~> 3.1'
 # Stanford gems
 gem 'assembly-image'
 gem 'assembly-objectfile', '~> 1.9'
-gem 'dir_validator'
+# https://github.com/sul-dlss-deprecated/dir_validator  <-- it's not maintained
+# gem 'dir_validator' # for possible use, per spec/test_data/project_config_fles/local_dev_rumsey.rb
 gem 'dor-services', '~> 8'
 gem 'dor-services-client'
 gem 'dor-workflow-client'
 gem 'druid-tools'
-gem 'harvestdor'
-gem 'modsulator'
 gem 'stanford-mods'
 gem 'config'
 gem 'pry-byebug' # helpful for debugging problems

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,9 +91,6 @@ GEM
     config (2.2.1)
       deep_merge (~> 1.2, >= 1.2.1)
       dry-validation (~> 1.0, >= 1.0.0)
-    confstruct (1.0.2)
-      hashie (~> 3.3)
-    connection_pool (2.2.2)
     coveralls (0.8.23)
       json (>= 1.8, < 3)
       simplecov (~> 0.16.1)
@@ -108,7 +105,6 @@ GEM
     deprecation (0.99.0)
       activesupport
     diff-lcs (1.3)
-    dir_validator (0.14.6)
     dlss-capistrano (3.5.0)
       capistrano (~> 3.0)
       capistrano-bundle_audit (>= 0.1.0)
@@ -211,12 +207,6 @@ GEM
     haml (5.1.2)
       temple (>= 0.8.0)
       tilt
-    harvestdor (0.3.1)
-      confstruct
-      faraday
-      net-http-persistent
-      nokogiri
-    hashie (3.6.0)
     honeybadger (3.3.1)
     hooks (0.4.1)
       uber (~> 0.0.14)
@@ -259,16 +249,7 @@ GEM
       iso-639
       nokogiri (>= 1.6.6)
       nom-xml (~> 1.0)
-    modsulator (2.0.0)
-      activesupport (~> 5.0)
-      deprecation (~> 0)
-      equivalent-xml (>= 0.6.0)
-      nokogiri (~> 1.8)
-      roo (>= 2.7.1)
-      stanford-mods-normalizer (~> 0.1)
     multipart-post (2.1.1)
-    net-http-persistent (3.1.0)
-      connection_pool (~> 2.2)
     net-scp (2.0.0)
       net-ssh (>= 2.6.5, < 6.0.0)
     net-ssh (5.2.0)
@@ -424,17 +405,14 @@ DEPENDENCIES
   config
   coveralls
   csv-mapper
-  dir_validator
   dlss-capistrano (~> 3.1)
   dor-services (~> 8)
   dor-services-client
   dor-workflow-client
   druid-tools
   equivalent-xml
-  harvestdor
   honeybadger (~> 3.1)
   jettywrapper
-  modsulator
   nokogiri
   pry-byebug
   rake

--- a/lib/pre_assembly/bundle.rb
+++ b/lib/pre_assembly/bundle.rb
@@ -359,6 +359,8 @@ module PreAssembly
     def run_dir_validation_code
       # Require the DirValidator code, run it, and return the validator.
       require @validate_bundle_dir[:code]
+      # 2020-02-26 there is no such thing as PreAssembly.validate_bundle_directory
+      #   except in spec/test_data/project_config_fles/local_dev_rumsey.rb
       dv = PreAssembly.validate_bundle_directory(@bundle_dir)
       dv
     end

--- a/lib/pre_assembly/digital_object.rb
+++ b/lib/pre_assembly/digital_object.rb
@@ -1,6 +1,5 @@
 # encoding: UTF-8
 require 'dor/services/client'
-require 'modsulator'
 
 module PreAssembly
 

--- a/spec/test_data/project_config_files/local_dev_rumsey.rb
+++ b/spec/test_data/project_config_files/local_dev_rumsey.rb
@@ -1,3 +1,4 @@
+# https://github.com/sul-dlss-deprecated/dir_validator  <-- it's not maintained
 require 'dir_validator'
 
 module PreAssembly
@@ -21,4 +22,3 @@ module PreAssembly
   end
 
 end
-


### PR DESCRIPTION
## Why was this change made?

To remove unused code.

Tony Z asked a question about which services needed modsulator url;  this caused me to search sul-dlss org for "modsulator" and I found it required but never used in this code base, AFAICT.

I also noticed harvestdor was required and not used, and dir_validator is only referenced in a test_data project config file.


## Was the usage documentation (e.g. README, consul, DevOpsDocs, wiki) updated?

n/a

## Does this change affect how this application integrates with other services?

n/a

If so, please confirm:
- [ ] change was tested on stage    and/or
- [ ] test added to sul-dlss/infrastructure-integration-test
