### PR TITLE
switch to new start accession endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'assembly-objectfile', '~> 1.9'
 # https://github.com/sul-dlss-deprecated/dir_validator  <-- it's not maintained
 # gem 'dir_validator' # for possible use, per spec/test_data/project_config_fles/local_dev_rumsey.rb
 gem 'dor-services', '~> 8'
-gem 'dor-services-client'
+gem 'dor-services-client', '~> 4.17'
 gem 'dor-workflow-client'
 gem 'druid-tools'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
       sshkit (~> 1.2)
     capistrano-shared_configs (0.2.2)
     childprocess (3.0.0)
-    cocina-models (0.25.0)
+    cocina-models (0.26.0)
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
       zeitwerk (~> 2.1)
@@ -133,11 +133,11 @@ GEM
       solrizer (~> 3.0)
       stanford-mods (>= 2.3.1)
       stanford-mods-normalizer (~> 0.1)
-    dor-services-client (4.16.0)
+    dor-services-client (4.17.0)
       activesupport (>= 4.2, < 7)
-      cocina-models (~> 0.25.0)
+      cocina-models (~> 0.26.0)
       deprecation
-      faraday (~> 0.15)
+      faraday (>= 0.15, < 2)
       moab-versioning (~> 4.0)
       zeitwerk (~> 2.1)
     dor-workflow-client (3.20.1)
@@ -407,7 +407,7 @@ DEPENDENCIES
   csv-mapper
   dlss-capistrano (~> 3.1)
   dor-services (~> 8)
-  dor-services-client
+  dor-services-client (~> 4.17)
   dor-workflow-client
   druid-tools
   equivalent-xml

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,8 +2,6 @@ dor_services:
   url: 'https://test'
   token: 'test'
 
-workflow_url: 'https://workflow_url'
-
 # sleep time in seconds between attempts to contact the dor service
 sleep_time: 0
 # the number of attempts to contact the dor web service before throwing an exception

--- a/lib/pre_assembly/digital_object.rb
+++ b/lib/pre_assembly/digital_object.rb
@@ -461,7 +461,7 @@ module PreAssembly
           description: 'lyberservices-scripts re-accession',
           opening_user_name: 'lyberservices-scripts'
         }
-      object_client.accession(version_params)
+      object_client.accession.start(version_params)
     end
   end
 end

--- a/lib/pre_assembly/digital_object.rb
+++ b/lib/pre_assembly/digital_object.rb
@@ -454,6 +454,7 @@ module PreAssembly
     end
 
     def start_accession
+      return unless @init_assembly_wf
       version_params =
         {
           significance: 'major',

--- a/lib/pre_assembly/digital_object.rb
+++ b/lib/pre_assembly/digital_object.rb
@@ -137,8 +137,7 @@ module PreAssembly
       generate_content_metadata unless @content_md_creation[:style].to_s == 'none'
       generate_technical_metadata
       generate_desc_metadata
-      create_new_version if openable?
-      initialize_assembly_workflow
+      start_accession
       log "    - pre_assemble(#{@pid}) finished"
     end
 
@@ -442,38 +441,26 @@ module PreAssembly
       version_client.openable?
     end
 
+    def object_client
+      @object_client ||= Dor::Services::Client.object(@druid.druid)
+    end
+
     def version_client
-      @version_client ||= Dor::Services::Client.object(@druid.druid).version
+      object_client.version
     end
 
     def current_object_version
       @current_object_version ||= version_client.current.to_i
     end
 
-    # When reaccessioning, we need to first open and close a version without kicking off accessionWF
-    def create_new_version
-      version_client.open(
-        significance: 'major',
-        description: 'lyberservices-scripts re-accession',
-        opening_user_name: 'lyberservices-scripts'
-      )
-      version_client.close(start_accession: false)
-    end
-
-    ####
-    # Initialize the assembly workflow.
-    ####
-
-    # Call web service to add assemblyWF to the object in DOR.
-    def initialize_assembly_workflow
-      return unless @init_assembly_wf
-      log "    - initialize_assembly_workflow()"
-
-      workflow_client.create_workflow_by_name(@druid.druid, 'assemblyWF', version: current_object_version)
-    end
-
-    def workflow_client
-      @workflow_client || Dor::Workflow::Client.new(url: Settings.workflow_url)
+    def start_accession
+      version_params =
+        {
+          significance: 'major',
+          description: 'lyberservices-scripts re-accession',
+          opening_user_name: 'lyberservices-scripts'
+        }
+      object_client.accession(version_params)
     end
   end
 end

--- a/spec/digital_object_spec.rb
+++ b/spec/digital_object_spec.rb
@@ -778,10 +778,11 @@ describe PreAssembly::DigitalObject do
       it 'does not start accessioning' do
         dor_services_client_object_version = instance_double(Dor::Services::Client::ObjectVersion, open: true, close: true)
         allow(dor_services_client_object_version).to receive(:current).and_return(5)
-        dor_services_client_object = instance_double(Dor::Services::Client::Object, version: dor_services_client_object_version)
+        accession_object = instance_double(Dor::Services::Client::Accession, start: true)
+        dor_services_client_object = instance_double(Dor::Services::Client::Object, version: dor_services_client_object_version, accession: accession_object)
         allow(Dor::Services::Client).to receive(:object).and_return(dor_services_client_object)
         allow(@dobj).to receive(:object_client).and_return(dor_services_client_object)
-        expect(dor_services_client_object).not_to receive(:accession)
+        expect(accession_object).not_to receive(:start)
         @dobj.send(:start_accession)
       end
     end
@@ -794,10 +795,11 @@ describe PreAssembly::DigitalObject do
       it 'starts accessioning' do
         dor_services_client_object_version = instance_double(Dor::Services::Client::ObjectVersion, open: true, close: true)
         allow(dor_services_client_object_version).to receive(:current).and_return(5)
-        dor_services_client_object = instance_double(Dor::Services::Client::Object, version: dor_services_client_object_version)
+        accession_object = instance_double(Dor::Services::Client::Accession, start: true)
+        dor_services_client_object = instance_double(Dor::Services::Client::Object, version: dor_services_client_object_version, accession: accession_object)
         allow(Dor::Services::Client).to receive(:object).and_return(dor_services_client_object)
         allow(@dobj).to receive(:object_client).and_return(dor_services_client_object)
-        expect(dor_services_client_object).to receive(:accession)
+        expect(accession_object).to receive(:start)
         @dobj.send(:start_accession)
       end
     end

--- a/spec/digital_object_spec.rb
+++ b/spec/digital_object_spec.rb
@@ -763,24 +763,7 @@ describe PreAssembly::DigitalObject do
     end
   end
 
-  describe '#create_new_version' do
-    let(:dor_services_client_object_version) { instance_double(Dor::Services::Client::ObjectVersion, open: true, close: true) }
-    let(:dor_services_client_object) { instance_double(Dor::Services::Client::Object, version: dor_services_client_object_version) }
-    let(:version_options) { { significance: 'major', description: 'lyberservices-scripts re-accession', opening_user_name: 'lyberservices-scripts' } }
-
-    before do
-      @dobj.druid = @druid
-      allow(Dor::Services::Client).to receive(:object).and_return(dor_services_client_object)
-    end
-
-    it 'opens and closes an object version' do
-      expect(dor_services_client_object_version).to receive(:open).with(**version_options)
-      expect(dor_services_client_object_version).to receive(:close).with(start_accession: false)
-      @dobj.send(:create_new_version)
-    end
-  end
-
-  describe '#initialize_assembly_workflow' do
+  describe '#start_accession' do
     before do
       allow(@dobj).to receive(:druid).and_return(@dru)
       @dobj.init_assembly_wf = true
@@ -792,39 +775,46 @@ describe PreAssembly::DigitalObject do
         @dobj.init_assembly_wf = false
       end
 
-      it 'skips initializing workflow' do
-        workflow_client = instance_double(Dor::Workflow::Client)
-        allow(@dobj).to receive(:workflow_client).and_return(workflow_client)
-        expect(workflow_client).not_to receive(:create_workflow_by_name)
-        @dobj.send(:initialize_assembly_workflow)
+      it 'does not start accessioning' do
+        dor_services_client_object_version = instance_double(Dor::Services::Client::ObjectVersion, open: true, close: true)
+        allow(dor_services_client_object_version).to receive(:current).and_return(5)
+        dor_services_client_object = instance_double(Dor::Services::Client::Object, version: dor_services_client_object_version)
+        allow(Dor::Services::Client).to receive(:object).and_return(dor_services_client_object)
+        allow(@dobj).to receive(:object_client).and_return(dor_services_client_object)
+        expect(dor_services_client_object).not_to receive(:accession)
+        @dobj.send(:start_accession)
       end
     end
 
     context 'when @init_assembly_wf is true' do
       before do
+        @dobj.init_assembly_wf = true
+      end
+
+      it 'starts accessioning' do
         dor_services_client_object_version = instance_double(Dor::Services::Client::ObjectVersion, open: true, close: true)
         allow(dor_services_client_object_version).to receive(:current).and_return(5)
         dor_services_client_object = instance_double(Dor::Services::Client::Object, version: dor_services_client_object_version)
         allow(Dor::Services::Client).to receive(:object).and_return(dor_services_client_object)
-      end
-
-      it 'starts the assembly workflow' do
-        workflow_client = instance_double(Dor::Workflow::Client)
-        allow(@dobj).to receive(:workflow_client).and_return(workflow_client)
-        expect(workflow_client).to receive(:create_workflow_by_name).with(@pid, 'assemblyWF', version: 5)
-        @dobj.send(:initialize_assembly_workflow)
+        allow(@dobj).to receive(:object_client).and_return(dor_services_client_object)
+        expect(dor_services_client_object).to receive(:accession)
+        @dobj.send(:start_accession)
       end
     end
 
     context 'when Dor::Workflow::Client raises' do
       before do
-        workflow_client = instance_double(Dor::Workflow::Client)
-        allow(workflow_client).to receive(:create_workflow_by_name).and_raise(StandardError)
-        allow(@dobj).to receive(:workflow_client).and_return(workflow_client)
+        @dobj.init_assembly_wf = true
       end
 
       it 'raises an exception' do
-        expect { @dobj.send(:initialize_assembly_workflow) }.to raise_error(StandardError)
+        dor_services_client_object_version = instance_double(Dor::Services::Client::ObjectVersion, open: true, close: true)
+        allow(dor_services_client_object_version).to receive(:current).and_return(5)
+        dor_services_client_object = instance_double(Dor::Services::Client::Object, version: dor_services_client_object_version)
+        allow(Dor::Services::Client).to receive(:object).and_return(dor_services_client_object)
+        allow(@dobj).to receive(:object_client).and_return(dor_services_client_object)
+        allow(dor_services_client_object).to receive(:accession).and_raise(StandardError)
+        expect { @dobj.send(:start_accession) }.to raise_error(StandardError)
       end
     end
   end


### PR DESCRIPTION
## Why was this change made?

Hold for testing/validation on stage before merging to master

part of sul-dlss/dor-services-app#702
Blocked by sul-dlss/dor-services-client#147

- [x] bump required version of dor-services-client when new release cut from PR linked to above
- [ ] remove now unneeded workflow URL config from shared configs (e.g. https://github.com/sul-dlss/shared_configs/blob/lyberservices-scripts-prod/config/settings/production.yml#L9 and https://github.com/sul-dlss/shared_configs/blob/lyberservices-scripts-stage/config/settings/test.yml#L9


## Was the usage documentation (e.g. README, consul, DevOpsDocs, wiki) updated?



## Does this change affect how this application integrates with other services?

If so, please confirm:
- [x] change was tested on stage    and/or
- [ ] test added to sul-dlss/infrastructure-integration-test
