### PR TITLE
unpin iso-639 gem as they fixed the problem with 0.3.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,10 +6,6 @@ gem 'csv-mapper'
 gem 'config'
 gem 'equivalent-xml'
 gem 'honeybadger', '~> 3.1'
-# iso-639 0.3.0 isn't compatible with ruby 2.5.  This declaration can be dropped when we upgrade to ruby 2.6
-# see https://github.com/alphabetum/iso-639/issues/12
-# iso-639 is used by dor-services gem via stanford-mods gem
-gem 'iso-639', '~> 0.2.10'
 gem 'nokogiri'
 gem 'pry-byebug' # helpful for debugging problems
 gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -217,7 +217,7 @@ GEM
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
-    iso-639 (0.2.10)
+    iso-639 (0.3.3)
     jaro_winkler (1.5.4)
     jettywrapper (2.0.5)
       activesupport (>= 3.0.0)
@@ -412,7 +412,6 @@ DEPENDENCIES
   druid-tools
   equivalent-xml
   honeybadger (~> 3.1)
-  iso-639 (~> 0.2.10)
   jettywrapper
   nokogiri
   pry-byebug


### PR DESCRIPTION
## Why was this change made?

unpin iso-639 gem as they fixed the problem with 0.3.3 (see https://github.com/alphabetum/iso-639/issues/12)

## Was the usage documentation (e.g. README, consul, DevOpsDocs, wiki) updated?

n/a

## Does this change affect how this application integrates with other services?

If so, please confirm:
- [ ] change was tested on stage    and/or
- [ ] test added to sul-dlss/infrastructure-integration-test
