### PR TITLE
Bump DSC for compatibility with latest cocina models

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'assembly-objectfile', '~> 1.9'
 # https://github.com/sul-dlss-deprecated/dir_validator  <-- it's not maintained
 # gem 'dir_validator' # for possible use, per spec/test_data/project_config_fles/local_dev_rumsey.rb
 gem 'dor-services', '~> 8'
-gem 'dor-services-client', '~> 4.17'
+gem 'dor-services-client', '~> 5.0'
 gem 'dor-workflow-client'
 gem 'druid-tools'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
       sshkit (~> 1.2)
     capistrano-shared_configs (0.2.2)
     childprocess (3.0.0)
-    cocina-models (0.32.0)
+    cocina-models (0.31.1)
       activesupport
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
@@ -139,9 +139,9 @@ GEM
       solrizer (~> 3.0)
       stanford-mods (>= 2.3.1)
       stanford-mods-normalizer (~> 0.1)
-    dor-services-client (4.20.0)
+    dor-services-client (5.1.0)
       activesupport (>= 4.2, < 7)
-      cocina-models (~> 0.29)
+      cocina-models (~> 0.31.0)
       deprecation
       faraday (>= 0.15, < 2)
       moab-versioning (~> 4.0)
@@ -420,7 +420,7 @@ DEPENDENCIES
   csv-mapper
   dlss-capistrano (~> 3.1)
   dor-services (~> 8)
-  dor-services-client (~> 4.17)
+  dor-services-client (~> 5.0)
   dor-workflow-client
   druid-tools
   equivalent-xml


### PR DESCRIPTION

## Why was this change made?

To better keep pace with cocina models changes and not break DSC.


## Was the usage documentation (e.g. README, consul, DevOpsDocs, wiki) updated?

No

## Does this change affect how this application integrates with other services?

Should prevent DSA integration breakage.