### PR TITLE
digital_object.determine_druid note added re: get_druid_from: suri option

### DIFF
--- a/lib/pre_assembly/digital_object.rb
+++ b/lib/pre_assembly/digital_object.rb
@@ -154,6 +154,8 @@ module PreAssembly
     ####
 
     def determine_druid
+      # NOTE:  PR https://github.com/sul-dlss/lyberservices-scripts/pull/42 removed the option to get it from suri;
+      #   if needed probably need to retool slightly to use registration service instead
       k = @project_style[:get_druid_from]
       log "    - determine_druid(#{k})"
       @pid   = method("get_pid_from_#{k}").call


### PR DESCRIPTION
## Why was this change made?

Out of an abundance of caution for PR sul-dlss/shared_configs/pull/1386

## How was this change tested?

test suite

## Which documentation and/or configurations were updated?

See sul-dlss/shared_configs/pull/1386.


NOTE:  please merge sul-dlss/shared_configs/pull/1386 after merging this.